### PR TITLE
Add compiledb, help and custom.py support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,12 @@ demo/bin/*
 !demo/bin/*.gdextension
 .sconsign*.dblite
 
+# Ignore custom.py
+custom.py
+
+# Ignore generated compile_commands.json
+compile_commands.json
+
 # Binaries
 *.o
 *.os

--- a/SConstruct
+++ b/SConstruct
@@ -1,8 +1,53 @@
 #!/usr/bin/env python
+import os
+
+
+def normalize_path(val, env):
+    return val if os.path.isabs(val) else os.path.join(env.Dir("#").abspath, val)
+
+
+def validate_parent_dir(key, val, env):
+    if not os.path.isdir(normalize_path(os.path.dirname(val), env)):
+        raise UserError("'%s' is not a directory: %s" % (key, os.path.dirname(val)))
+
 
 libname = "EXTENSION-NAME"
 
-env = SConscript("godot-cpp/SConstruct")
+localEnv = Environment(tools=["default"], PLATFORM="")
+
+customs = ["custom.py"]
+customs = [os.path.abspath(path) for path in customs]
+
+opts = Variables(customs, ARGUMENTS)
+opts.Add(
+    BoolVariable(
+        key="compiledb",
+        help="Generate compilation DB (`compile_commands.json`) for external tools",
+        default=localEnv.get("compiledb", False),
+    )
+)
+opts.Add(
+    PathVariable(
+        key="compiledb_file",
+        help="Path to a custom `compile_commands.json` file",
+        default=localEnv.get("compiledb_file", "compile_commands.json"),
+        validator=validate_parent_dir,
+    )
+)
+opts.Update(localEnv)
+
+Help(opts.GenerateHelpText(localEnv))
+
+env = localEnv.Clone()
+env["compiledb"] = False
+
+env.Tool("compilation_db")
+compilation_db = env.CompilationDatabase(
+    normalize_path(localEnv["compiledb_file"], localEnv)
+)
+env.Alias("compiledb", compilation_db)
+
+env = SConscript("godot-cpp/SConstruct", {"env": env, "customs": customs})
 
 env.Append(CPPPATH=["src/"])
 sources = Glob("src/*.cpp")
@@ -19,4 +64,7 @@ else:
         source=sources,
     )
 
-Default(library)
+default_args = [library]
+if localEnv.get("compiledb", False):
+    default_args += [compilation_db]
+Default(*default_args)


### PR DESCRIPTION
As the title says, it adds compiledb and custom.py support.

This is needed for new users for the process to be as smooth as possible. This includes the generation of compile_commands.json to enable autocompletion while creating C++ code.

Depends on https://github.com/godotengine/godot-cpp/pull/1220

**Edit:** Added help support too
