### PR TITLE
Fix formatting of `compatibility_minimum`

### DIFF
--- a/demo/bin/example.gdextension
+++ b/demo/bin/example.gdextension
@@ -1,7 +1,7 @@
 [configuration]
 
 entry_symbol = "example_library_init"
-compatibility_minimum = 4.1
+compatibility_minimum = "4.1"
 
 [libraries]
 


### PR DESCRIPTION
Without quotes the values is parsed as a float, breaking in various cases.

* See: https://github.com/godotengine/godot-cpp/pull/1226