### PR TITLE
CI: Pin MinGW version to 12.2.0 to fix install issue

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -81,6 +81,8 @@ jobs:
       - name: Setup MinGW for Windows/MinGW build
         if: ${{ matrix.platform == 'windows' }}
         uses: egor-tensin/setup-mingw@v2
+        with:
+          version: 12.2.0
 
       - name: Compile godot-cpp
         shell: sh


### PR DESCRIPTION
Counterpart to https://github.com/godotengine/godot-cpp/pull/1259.