### PR TITLE
Fix GitHub issue template not being parsed as form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,7 +6,7 @@ body:
   attributes:
     value: |
       - Write a descriptive issue title above.
-      - Search [open]() and [closed]() issues to ensure it has not already been reported.
+      - Search [open](https://github.com/godotengine/godot-cpp-template/issues) and [closed](https://github.com/godotengine/godot-cpp-template/issues?q=is%3Aissue+is%3Aclosed) issues to ensure it has not already been reported.
 - type: input
   attributes:
     label: Godot version

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+
+contact_links:
+  - name: Godot proposals
+    url: https://github.com/godotengine/godot-proposals
+    about: Please submit feature proposals on the Godot proposals repository, not here.
+
+  - name: Godot documentation repository
+    url: https://github.com/godotengine/godot-docs
+    about: Please report issues with documentation on the Godot documentation repository, not here.
+
+  - name: Godot community channels
+    url: https://godotengine.org/community
+    about: Please ask for technical support on one of the other community channels, not here.


### PR DESCRIPTION
It would show like this:

![image](https://github.com/godotengine/godot-cpp-template/assets/4701338/c0c64aa1-cf75-49c4-9c90-5ae052b377bd)
