### PR TITLE
Fix library copy command

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -65,16 +65,7 @@ library = env.SharedLibrary(
     source=sources,
 )
 
-
-def copy_bin_to_projectdir(target, source, env):
-    import shutil
-
-    targetfrom = "bin/{}/lib{}".format(env["platform"], file)
-    targetdest = "{}/bin/{}/lib{}".format(projectdir, env["platform"], file)
-    shutil.copyfile(targetfrom, targetdest)
-
-
-copy = env.Command(libraryfile, None, copy_bin_to_projectdir)
+copy = env.InstallAs("{}/bin/{}/lib{}".format(projectdir, env["platform"], file), library)
 
 default_args = [library, copy]
 if localEnv.get("compiledb", False):


### PR DESCRIPTION
Use InstallAs with the correct target/source order instead of Command.

Closes #19 
Fixes #17