### PR TITLE
Fix binary location and name and add web wasm support

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -57,7 +57,7 @@ file = "{}{}{}".format(libname, env["suffix"], env["SHLIBSUFFIX"])
 
 if env["platform"] == "macos" or env["platform"] == "ios":
     platlibname = "{}.{}.{}".format(libname, env["platform"], env["target"])
-    file = "{}.framework/{}".format(env["platform"], platlibname, platlibname)
+    file = "{}.framework/{}".format(platlibname, platlibname)
 
 libraryfile = "bin/{}/{}".format(env["platform"], file)
 library = env.SharedLibrary(
@@ -65,7 +65,7 @@ library = env.SharedLibrary(
     source=sources,
 )
 
-copy = env.InstallAs("{}/bin/{}/lib{}".format(projectdir, env["platform"], file), library)
+copy = env.InstallAs("{}/bin/{}/{}".format(projectdir, env["platform"], file), library)
 
 default_args = [library, copy]
 if localEnv.get("compiledb", False):

--- a/demo/bin/example.gdextension
+++ b/demo/bin/example.gdextension
@@ -2,24 +2,34 @@
 
 entry_symbol = "example_library_init"
 compatibility_minimum = "4.1"
+reloadable = true
 
 [libraries]
 
-macos.debug = "res://bin/libgdexample.macos.template_debug.framework"
-macos.release = "res://bin/libgdexample.macos.template_release.framework"
-ios.debug = "res://bin/libgdexample.ios.template_debug.framework"
-ios.release = "res://bin/libgdexample.ios.template_release.framework"
-windows.debug.x86_32 = "res://bin/libgdexample.windows.template_debug.x86_32.dll"
-windows.release.x86_32 = "res://bin/libgdexample.windows.template_release.x86_32.dll"
-windows.debug.x86_64 = "res://bin/libgdexample.windows.template_debug.x86_64.dll"
-windows.release.x86_64 = "res://bin/libgdexample.windows.template_release.x86_64.dll"
-linux.debug.x86_64 = "res://bin/libgdexample.linux.template_debug.x86_64.so"
-linux.release.x86_64 = "res://bin/libgdexample.linux.template_release.x86_64.so"
-linux.debug.arm64 = "res://bin/libgdexample.linux.template_debug.arm64.so"
-linux.release.arm64 = "res://bin/libgdexample.linux.template_release.arm64.so"
-linux.debug.rv64 = "res://bin/libgdexample.linux.template_debug.rv64.so"
-linux.release.rv64 = "res://bin/libgdexample.linux.template_release.rv64.so"
-android.debug.x86_64 = "res://bin/libgdexample.android.template_debug.x86_64.so"
-android.release.x86_64 = "res://bin/libgdexample.android.template_release.x86_64.so"
-android.debug.arm64 = "res://bin/libgdexample.android.template_debug.arm64.so"
-android.release.arm64 = "res://bin/libgdexample.android.template_release.arm64.so"
+macos.debug = "res://bin/macos/EXTENSION-NAME.macos.template_debug.framework"
+macos.release = "res://bin/macos/EXTENSION-NAME.macos.template_release.framework"
+
+windows.debug.x86_32 = "res://bin/windows/EXTENSION-NAME.windows.template_debug.x86_32.dll"
+windows.release.x86_32 = "res://bin/windows/EXTENSION-NAME.windows.template_release.x86_32.dll"
+windows.debug.x86_64 = "res://bin/windows/EXTENSION-NAME.windows.template_debug.x86_64.dll"
+windows.release.x86_64 = "res://bin/windows/EXTENSION-NAME.windows.template_release.x86_64.dll"
+
+linux.debug.x86_64 = "res://bin/linux/EXTENSION-NAME.linux.template_debug.x86_64.so"
+linux.release.x86_64 = "res://bin/linux/EXTENSION-NAME.linux.template_release.x86_64.so"
+linux.debug.arm64 = "res://bin/linux/EXTENSION-NAME.linux.template_debug.arm64.so"
+linux.release.arm64 = "res://bin/linux/EXTENSION-NAME.linux.template_release.arm64.so"
+linux.debug.rv64 = "res://bin/linux/EXTENSION-NAME.linux.template_debug.rv64.so"
+linux.release.rv64 = "res://bin/linux/EXTENSION-NAME.linux.template_release.rv64.so"
+
+android.debug.x86_64 = "res://bin/android/EXTENSION-NAME.android.template_debug.x86_64.so"
+android.release.x86_64 = "res://bin/android/EXTENSION-NAME.android.template_release.x86_64.so"
+android.debug.arm64 = "res://bin/android/EXTENSION-NAME.android.template_debug.arm64.so"
+android.release.arm64 = "res://bin/android/EXTENSION-NAME.android.template_release.arm64.so"
+
+ios.debug = "res://bin/ios/EXTENSION-NAME.ios.template_debug.xcframework"
+ios.release = "res://bin/ios/EXTENSION-NAME.ios.template_release.xcframework"
+
+web.debug.threads.wasm32 = "res://bin/web/EXTENSION-NAME.web.template_debug.wasm32.wasm"
+web.release.threads.wasm32 = "res://bin/web/EXTENSION-NAME.web.template_release.wasm32.wasm"
+web.debug.wasm32 = "res://bin/web/EXTENSION-NAME.web.template_debug.wasm32.nothreads.wasm"
+web.release.wasm32 = "res://bin/web/EXTENSION-NAME.web.template_release.wasm32.nothreads.wasm"

--- a/demo/project.godot
+++ b/demo/project.godot
@@ -11,5 +11,5 @@ config_version=5
 [application]
 
 config/name="godot cpp template"
-config/features=PackedStringArray("4.1", "Forward Plus")
+config/features=PackedStringArray("4.2", "Forward Plus")
 config/icon="res://icon.svg"


### PR DESCRIPTION
These changes make the library name consistent throughout the template when starting to work on a new GDExtension.