### PR TITLE
Fix android builds, improved flexibility of matrix builds, fix artifact upload

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -28,19 +28,32 @@ runs:
   using: composite
   steps:
 # Android only
-    - name: Android - Set up Java 11
-      uses: actions/setup-java@v3
+    - name: Android - Set up Java 17
+      uses: actions/setup-java@v4
       if: ${{ inputs.platform == 'android' }}
       with:
         distribution: temurin
-        java-version: 11
+        java-version: 17
 
-    - name: Android - dependencies
-      uses: nttld/setup-ndk@v1
+    - name: Android - Remove existing Android SDK, and set up ENV vars
       if: ${{ inputs.platform == 'android' }}
+      shell: sh
+      run: |
+        sudo rm -r /usr/local/lib/android/sdk/**
+        export ANDROID_HOME=/usr/local/lib/android/sdk
+        export ANDROID_SDK_ROOT=$ANDROID_HOME
+        export ANDROID_NDK_VERSION=23.2.8568313
+        export ANDROID_NDK_ROOT=${ANDROID_SDK_ROOT}/ndk/${ANDROID_NDK_VERSION}
+        echo "ANDROID_HOME=$ANDROID_HOME" >> "$GITHUB_ENV"
+        echo "ANDROID_SDK_ROOT=$ANDROID_SDK_ROOT" >> "$GITHUB_ENV"
+        echo "ANDROID_NDK_VERSION=$ANDROID_NDK_VERSION" >> "$GITHUB_ENV"
+        echo "ANDROID_NDK_ROOT=$ANDROID_NDK_ROOT" >> "$GITHUB_ENV"
+
+    - name: Android - Set up Android SDK
+      if: ${{ inputs.platform == 'android' }}
+      uses: android-actions/setup-android@v3
       with:
-        ndk-version: r23c
-        link-to-sdk: true
+        packages: "ndk;${{ env.ANDROID_NDK_VERSION }} cmdline-tools;latest build-tools;34.0.0 platforms;android-34 cmake;3.22.1"
 # Linux only
     - name: Linux - dependencies
       if: ${{ inputs.platform == 'linux' }}
@@ -69,7 +82,7 @@ runs:
 # Dependencies of godot
     # Use python 3.x release (works cross platform)
     - name: Set up Python 3.x
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         # Semantic version range syntax or exact version of a Python version
         python-version: "3.x"
@@ -83,7 +96,7 @@ runs:
         scons --version
 # Build
     - name: Cache .scons_cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ${{ github.workspace }}/${{ inputs.gdextension-location }}/${{ inputs.scons-cache }}/

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -12,111 +12,97 @@ jobs:
       fail-fast: false
       matrix:
         include:
+        # Debug templates
           - platform: linux
             float-precision: single
             arch: x86_64
-            os: ubuntu-20.04
-          - platform: windows
-            float-precision: single
-            arch: x86_32
-            os: windows-latest
-          - platform: windows
-            float-precision: single
-            arch: x86_64
-            os: windows-latest
-          - platform: macos
-            float-precision: single
-            arch: universal
-            os: macos-latest
-          - platform: android
-            float-precision: single
-            arch: arm64
-            os: ubuntu-20.04
-          - platform: android
-            float-precision: single
-            arch: arm32
-            os: ubuntu-20.04
-          - platform: android
-            float-precision: single
-            arch: x86_64
-            os: ubuntu-20.04
-          - platform: android
-            float-precision: single
-            arch: x86_32
-            os: ubuntu-20.04
-          - platform: ios
-            float-precision: single
-            arch: arm64
-            os: macos-latest
-          - platform: web
-            float-precision: single
-            arch: wasm32
+            target-type: template_debug
             os: ubuntu-20.04
 
+          - platform: windows
+            float-precision: single
+            arch: x86_32
+            target-type: template_debug
+            os: windows-latest
+
+          - platform: windows
+            float-precision: single
+            arch: x86_64
+            target-type: template_debug
+            os: windows-latest
+
+          - platform: macos
+            float-precision: single
+            arch: universal
+            target-type: template_debug
+            os: macos-latest
+
+          - platform: android
+            float-precision: single
+            arch: arm64
+            target-type: template_debug
+            os: ubuntu-20.04
+
+          - platform: android
+            float-precision: single
+            arch: arm32
+            target-type: template_debug
+            os: ubuntu-20.04
+
+          - platform: android
+            float-precision: single
+            arch: x86_64
+            target-type: template_debug
+            os: ubuntu-20.04
+
+          - platform: android
+            float-precision: single
+            arch: x86_32
+            target-type: template_debug
+            os: ubuntu-20.04
+
+          - platform: ios
+            float-precision: single
+            arch: arm64
+            target-type: template_debug
+            os: macos-latest
+
+          - platform: web
+            float-precision: single
+            arch: wasm32
+            target-type: template_debug
+            os: ubuntu-20.04
+
+        # Release templates
+          - platform: linux
+            float-precision: single
+            arch: x86_64
+            target-type: template_release
+            os: ubuntu-20.04
+
+        # Double precision templates
           - platform: linux
             float-precision: double
             arch: x86_64
-            os: ubuntu-20.04
-          - platform: windows
-            float-precision: double
-            arch: x86_32
-            os: windows-latest
-          - platform: windows
-            float-precision: double
-            arch: x86_64
-            os: windows-latest
-          - platform: macos
-            float-precision: double
-            arch: universal
-            os: macos-latest
-          - platform: android
-            float-precision: double
-            arch: arm64
-            os: ubuntu-20.04
-          - platform: android
-            float-precision: double
-            arch: arm32
-            os: ubuntu-20.04
-          - platform: android
-            float-precision: double
-            arch: x86_64
-            os: ubuntu-20.04
-          - platform: android
-            float-precision: double
-            arch: x86_32
-            os: ubuntu-20.04
-          - platform: ios
-            float-precision: double
-            arch: arm64
-            os: macos-latest
-          - platform: web
-            float-precision: double
-            arch: wasm32
+            target-type: template_release
             os: ubuntu-20.04
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
           fetch-depth: 0
-# Lint
-      #- name: Setup clang-format
-      #  shell: bash
-      #  run: |
-      #    python -m pip install clang-format
-      #- name: Run clang-format
-      #  shell: bash
-      #  run: |
-      #    clang-format src/** --dry-run --Werror
+
 # Build
-      - name: 🔗 GDExtension Build
+      - name: 🔗 GDExtension Debug Build
         uses: ./.github/actions/build
         with:
           platform: ${{ matrix.platform }}
           arch: ${{ matrix.arch }}
           float-precision: ${{ matrix.float-precision }}
-          build-target-type: template_release
+          build-target-type: ${{ matrix.target-type }}
+
 # Sign
       - name: Mac Sign
         # Disable sign if secrets are not set
@@ -139,8 +125,18 @@ jobs:
         run: |
           Remove-Item bin/* -Include *.exp,*.lib,*.pdb -Force
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: godot-cpp-template
+          name: godot-cpp-template-${{ matrix.platform }}-${{ matrix.arch }}-${{ matrix.float-precision }}-${{ matrix.target-type }}
           path: |
             ${{ github.workspace }}/bin/**
+  merge:
+    runs-on: ubuntu-20.04
+    needs: build
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: godot-cpp-template
+          pattern: godot-cpp-template-*
+          delete-merged: true

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -80,12 +80,182 @@ jobs:
             target-type: template_release
             os: ubuntu-20.04
 
+          # - platform: windows
+          #   float-precision: single
+          #   arch: x86_32
+          #   target-type: template_release
+          #   os: windows-latest
+
+          # - platform: windows
+          #   float-precision: single
+          #   arch: x86_64
+          #   target-type: template_release
+          #   os: windows-latest
+
+          # - platform: macos
+          #   float-precision: single
+          #   arch: universal
+          #   target-type: template_release
+          #   os: macos-latest
+
+          # - platform: android
+          #   float-precision: single
+          #   arch: arm64
+          #   target-type: template_release
+          #   os: ubuntu-20.04
+
+          # - platform: android
+          #   float-precision: single
+          #   arch: arm32
+          #   target-type: template_release
+          #   os: ubuntu-20.04
+
+          # - platform: android
+          #   float-precision: single
+          #   arch: x86_64
+          #   target-type: template_release
+          #   os: ubuntu-20.04
+
+          # - platform: android
+          #   float-precision: single
+          #   arch: x86_32
+          #   target-type: template_release
+          #   os: ubuntu-20.04
+
+          # - platform: ios
+          #   float-precision: single
+          #   arch: arm64
+          #   target-type: template_release
+          #   os: macos-latest
+
+          # - platform: web
+          #   float-precision: single
+          #   arch: wasm32
+          #   target-type: template_release
+          #   os: ubuntu-20.04
+
         # Double precision templates
+        # Double precision debug templates
+          - platform: linux
+            float-precision: double
+            arch: x86_64
+            target-type: template_debug
+            os: ubuntu-20.04
+
+          - platform: windows
+            float-precision: double
+            arch: x86_32
+            target-type: template_debug
+            os: windows-latest
+
+          - platform: windows
+            float-precision: double
+            arch: x86_64
+            target-type: template_debug
+            os: windows-latest
+
+          - platform: macos
+            float-precision: double
+            arch: universal
+            target-type: template_debug
+            os: macos-latest
+
+          - platform: android
+            float-precision: double
+            arch: arm64
+            target-type: template_debug
+            os: ubuntu-20.04
+
+          - platform: android
+            float-precision: double
+            arch: arm32
+            target-type: template_debug
+            os: ubuntu-20.04
+
+          - platform: android
+            float-precision: double
+            arch: x86_64
+            target-type: template_debug
+            os: ubuntu-20.04
+
+          - platform: android
+            float-precision: double
+            arch: x86_32
+            target-type: template_debug
+            os: ubuntu-20.04
+
+          - platform: ios
+            float-precision: double
+            arch: arm64
+            target-type: template_debug
+            os: macos-latest
+
+          - platform: web
+            float-precision: double
+            arch: wasm32
+            target-type: template_debug
+            os: ubuntu-20.04
+
+        # Double precision release templates
           - platform: linux
             float-precision: double
             arch: x86_64
             target-type: template_release
             os: ubuntu-20.04
+
+          # - platform: windows
+          #   float-precision: double
+          #   arch: x86_32
+          #   target-type: template_release
+          #   os: windows-latest
+
+          # - platform: windows
+          #   float-precision: double
+          #   arch: x86_64
+          #   target-type: template_release
+          #   os: windows-latest
+
+          # - platform: macos
+          #   float-precision: double
+          #   arch: universal
+          #   target-type: template_release
+          #   os: macos-latest
+
+          # - platform: android
+          #   float-precision: double
+          #   arch: arm64
+          #   target-type: template_release
+          #   os: ubuntu-20.04
+
+          # - platform: android
+          #   float-precision: double
+          #   arch: arm32
+          #   target-type: template_release
+          #   os: ubuntu-20.04
+
+          # - platform: android
+          #   float-precision: double
+          #   arch: x86_64
+          #   target-type: template_release
+          #   os: ubuntu-20.04
+
+          # - platform: android
+          #   float-precision: double
+          #   arch: x86_32
+          #   target-type: template_release
+          #   os: ubuntu-20.04
+
+          # - platform: ios
+          #   float-precision: double
+          #   arch: arm64
+          #   target-type: template_release
+          #   os: macos-latest
+
+          # - platform: web
+          #   float-precision: double
+          #   arch: wasm32
+          #   target-type: template_release
+          #   os: ubuntu-20.04
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -130,6 +300,9 @@ jobs:
           name: godot-cpp-template-${{ matrix.platform }}-${{ matrix.arch }}-${{ matrix.float-precision }}-${{ matrix.target-type }}
           path: |
             ${{ github.workspace }}/bin/**
+
+  # Merges all the build artifacts together into a single godot-cpp-template artifact.
+  # If you comment out this step, all the builds will be uploaded individually.
   merge:
     runs-on: ubuntu-20.04
     needs: build

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -264,6 +264,16 @@ jobs:
           submodules: true
           fetch-depth: 0
 
+# Lint
+      #- name: Setup clang-format
+      #  shell: bash
+      #  run: |
+      #    python -m pip install clang-format
+      #- name: Run clang-format
+      #  shell: bash
+      #  run: |
+      #    clang-format src/** --dry-run --Werror
+
 # Build
       - name: 🔗 GDExtension Debug Build
         uses: ./.github/actions/build


### PR DESCRIPTION
- Add target-type in builds to let users customize what build type they want to make (`target_release` or `target_debug`)
- Fix android builds using old sdk
- Fix artifact upload issue by uploading artifacts separately and then merging the artifacts

Closes #31 (Builds on PR #33)
Closes #30