### PR TITLE
Print an error if the godot-cpp submodule hasn't been initialized

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 import os
+import sys
+
+from methods import print_error
 
 
 def normalize_path(val, env):
@@ -47,6 +50,19 @@ compilation_db = env.CompilationDatabase(
     normalize_path(localEnv["compiledb_file"], localEnv)
 )
 env.Alias("compiledb", compilation_db)
+
+submodule_initialized = False
+dir_name = 'godot-cpp'
+if os.path.isdir(dir_name):
+    if os.listdir(dir_name):
+        submodule_initialized = True
+
+if not submodule_initialized:
+    print_error("""godot-cpp is not available within this folder, as Git submodules haven't been initialized.
+Run the following command to download godot-cpp:
+
+    git submodule update --init --recursive""")
+    sys.exit(1)
 
 env = SConscript("godot-cpp/SConstruct", {"env": env, "customs": customs})
 

--- a/methods.py
+++ b/methods.py
@@ -1,0 +1,52 @@
+import os
+import sys
+from enum import Enum
+
+# Colors are disabled in non-TTY environments such as pipes. This means
+# that if output is redirected to a file, it won't contain color codes.
+# Colors are always enabled on continuous integration.
+_colorize = bool(sys.stdout.isatty() or os.environ.get("CI"))
+
+
+class ANSI(Enum):
+    """
+    Enum class for adding ansi colorcodes directly into strings.
+    Automatically converts values to strings representing their
+    internal value, or an empty string in a non-colorized scope.
+    """
+
+    RESET = "\x1b[0m"
+
+    BOLD = "\x1b[1m"
+    ITALIC = "\x1b[3m"
+    UNDERLINE = "\x1b[4m"
+    STRIKETHROUGH = "\x1b[9m"
+    REGULAR = "\x1b[22;23;24;29m"
+
+    BLACK = "\x1b[30m"
+    RED = "\x1b[31m"
+    GREEN = "\x1b[32m"
+    YELLOW = "\x1b[33m"
+    BLUE = "\x1b[34m"
+    MAGENTA = "\x1b[35m"
+    CYAN = "\x1b[36m"
+    WHITE = "\x1b[37m"
+
+    PURPLE = "\x1b[38;5;93m"
+    PINK = "\x1b[38;5;206m"
+    ORANGE = "\x1b[38;5;214m"
+    GRAY = "\x1b[38;5;244m"
+
+    def __str__(self) -> str:
+        global _colorize
+        return str(self.value) if _colorize else ""
+
+
+def print_warning(*values: object) -> None:
+    """Prints a warning message with formatting."""
+    print(f"{ANSI.YELLOW}{ANSI.BOLD}WARNING:{ANSI.REGULAR}", *values, ANSI.RESET, file=sys.stderr)
+
+
+def print_error(*values: object) -> None:
+    """Prints an error message with formatting."""
+    print(f"{ANSI.RED}{ANSI.BOLD}ERROR:{ANSI.REGULAR}", *values, ANSI.RESET, file=sys.stderr)


### PR DESCRIPTION
This makes the error that is printed easier to understand, with a command given as a solution to run.

The error message is also colored to match how core Godot displays this kind of build errors.

## Preview

![image](https://github.com/user-attachments/assets/23c16925-c83b-45c8-8e72-9ef261033692)

