### PR TITLE
Clean up unnecessary compiledb parameters

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -2,15 +2,6 @@
 import os
 
 
-def normalize_path(val, env):
-    return val if os.path.isabs(val) else os.path.join(env.Dir("#").abspath, val)
-
-
-def validate_parent_dir(key, val, env):
-    if not os.path.isdir(normalize_path(os.path.dirname(val), env)):
-        raise UserError("'%s' is not a directory: %s" % (key, os.path.dirname(val)))
-
-
 libname = "EXTENSION-NAME"
 projectdir = "demo"
 
@@ -20,33 +11,11 @@ customs = ["custom.py"]
 customs = [os.path.abspath(path) for path in customs]
 
 opts = Variables(customs, ARGUMENTS)
-opts.Add(
-    BoolVariable(
-        key="compiledb",
-        help="Generate compilation DB (`compile_commands.json`) for external tools",
-        default=localEnv.get("compiledb", False),
-    )
-)
-opts.Add(
-    PathVariable(
-        key="compiledb_file",
-        help="Path to a custom `compile_commands.json` file",
-        default=localEnv.get("compiledb_file", "compile_commands.json"),
-        validator=validate_parent_dir,
-    )
-)
 opts.Update(localEnv)
 
 Help(opts.GenerateHelpText(localEnv))
 
 env = localEnv.Clone()
-env["compiledb"] = False
-
-env.Tool("compilation_db")
-compilation_db = env.CompilationDatabase(
-    normalize_path(localEnv["compiledb_file"], localEnv)
-)
-env.Alias("compiledb", compilation_db)
 
 env = SConscript("godot-cpp/SConstruct", {"env": env, "customs": customs})
 
@@ -75,6 +44,4 @@ library = env.SharedLibrary(
 copy = env.InstallAs("{}/bin/{}/lib{}".format(projectdir, env["platform"], file), library)
 
 default_args = [library, copy]
-if localEnv.get("compiledb", False):
-    default_args += [compilation_db]
 Default(*default_args)


### PR DESCRIPTION
I found that the compiledb parameter option in SConstruct may be redundant, because the game project is build together with godot-cpp, and there are already related builds and parameters for compiledb in godot-cpp.

So I removed the parameters of computedb and kept an example argument in its place as a replacement.
