### PR TITLE
In the readme suggested action, use checkout and upload-artifact v4.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
           fetch-depth: 0
@@ -110,7 +110,7 @@ jobs:
           APPLE_DEV_TEAM_ID: ${{ secrets.APPLE_DEV_TEAM_ID }}
           APPLE_DEV_APP_ID: ${{ secrets.APPLE_DEV_APP_ID }}
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: GDExtension
           path: |


### PR DESCRIPTION
v3 has been deprecated for a while, and the bump to v4 is painless (and has been done on the action itself already).