### PR TITLE
Fix github action paths / parameters

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -15,14 +15,20 @@ inputs:
     default: 'template_debug'
     description: Build type (template_debug or template_release).
   scons-cache:
-    default: .scons-cache/
-    description: Scons cache location.
+    default: '.scons-cache/'
+    description: Scons cache folder name, relative to each scons directory. Must not contain relative path signifiers (. or ..). Must be a transparent path part (empty or 'path/to/directory/', ending in a slash).
   em_version:
     default: 3.1.62
     description: Emscripten version.
-  em_cache_folder:
+  em-cache-directory:
     default: emsdk-cache
-    description: Emscripten cache folder.
+    description: Emscripten cache directory.
+  godot-cpp-directory:
+    default: 'godot-cpp/'
+    description: Location of godot-cpp in the repository. Must not contain relative path signifiers (. or ..). Must be a transparent path part (empty or 'path/to/directory/', ending in a slash).
+  gdextension-directory:
+    default: ''
+    description: Location of the gdextension project within the repository. Must not contain relative path signifiers (. or ..). Must be a transparent path part (empty or 'path/to/directory/', ending in a slash).
 
 runs:
   using: composite
@@ -67,7 +73,7 @@ runs:
       uses: mymindstorm/setup-emsdk@v13
       with:
         version: ${{ inputs.em_version }}
-        actions-cache-folder: ${{ inputs.em_cache_folder }}.${{ inputs.float-precision }}.${{ inputs.build-target-type }}
+        actions-cache-folder: ${{ inputs.em-cache-directory }}.${{ inputs.float-precision }}.${{ inputs.build-target-type }}
     - name: Web - Verify Emscripten setup
       if: ${{ inputs.platform == 'web' }}
       shell: sh
@@ -99,22 +105,22 @@ runs:
       uses: actions/cache@v4
       with:
         path: |
-          ${{ github.workspace }}/${{ inputs.gdextension-location }}/${{ inputs.scons-cache }}/
-          ${{ github.workspace }}/${{ inputs.godot-cpp }}/${{ inputs.scons-cache }}/
+          ${{ github.workspace }}/${{ inputs.gdextension-directory }}${{ inputs.scons-cache }}
+          ${{ github.workspace }}/${{ inputs.godot-cpp-directory }}${{ inputs.scons-cache }}
         key: ${{ inputs.platform }}_${{ inputs.arch }}_${{ inputs.float-precision }}_${{ inputs.build-target-type }}_cache
 # Build godot-cpp
     - name: Build godot-cpp Debug Build
       shell: sh
       env:
-        SCONS_CACHE: ${{ github.workspace }}/${{ inputs.godot-cpp }}/${{ inputs.scons-cache }}/
+        SCONS_CACHE: ${{ github.workspace }}/${{ inputs.godot-cpp-directory }}${{ inputs.scons-cache }}
       run: |
         scons target=${{ inputs.build-target-type }} platform=${{ inputs.platform }} arch=${{ inputs.arch }} generate_bindings=yes precision=${{ inputs.float-precision }}
-      working-directory: ${{ inputs.godot-cpp }}
+      working-directory: ${{ inputs.godot-cpp-directory }}
 # Build gdextension
     - name: Build GDExtension Debug Build
       shell: sh
       env:
-        SCONS_CACHE: ${{ github.workspace }}/${{ inputs.gdextension-location }}/${{ inputs.scons-cache }}/
+        SCONS_CACHE: ${{ github.workspace }}/${{ inputs.gdextension-directory }}${{ inputs.scons-cache }}
       run: |
         scons target=${{ inputs.build-target-type }} platform=${{ inputs.platform }} arch=${{ inputs.arch }} precision=${{ inputs.float-precision }}
-      working-directory: ${{ inputs.gdextension-location }}
+      working-directory: ${{ inputs.gdextension-directory }}


### PR DESCRIPTION
This does several things:

- It actually publishes / fixes the parameters, intended for different folder setups of the project.
- godot-cpp is actually built now, as intended by the action author.
    - I'm not sure if we even need to, given that the latter command builds it fine. But that's for another PR to decide.
- It fixes scons caches, making builds a lot faster (I tested this; repeated builds now fly by very fast).
- It fixes a build error on windows when compiling with doc data.
