### PR TITLE
Ignore files generated for documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ custom.py
 # Ignore generated compile_commands.json
 compile_commands.json
 
+# Ignore files generated for documentation
+/src/gen
+
 # Binaries
 *.o
 *.os


### PR DESCRIPTION
This adds a line to `.gitignore` to ignore the files generated for documentation.