### PR TITLE
Update emscripten to the version used by godotengine - 3.1.62

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -18,7 +18,7 @@ inputs:
     default: .scons-cache/
     description: Scons cache location.
   em_version:
-    default: 3.1.39
+    default: 3.1.62
     description: Emscripten version.
   em_cache_folder:
     default: emsdk-cache


### PR DESCRIPTION
As per https://github.com/godotengine/godot/pull/96610

we now use 3.1.62 in godotengine so we should align them