### PR TITLE
Reset github checkout fetch-depth to 1.

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -262,7 +262,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
-          fetch-depth: 0
 
 # Lint
       #- name: Setup clang-format

--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
-          fetch-depth: 0
       - name: 🔗 GDExtension Build
         uses: godotengine/godot-cpp-template/.github/actions/build@main
         with:


### PR DESCRIPTION
This slightly speeds up the checkout. Setting fetch-depth to 0 fetches all branches and tags, which should not be required.