### PR TITLE
Remove unneeded godot-cpp build step from the GitHub action.

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -23,9 +23,6 @@ inputs:
   em-cache-directory:
     default: emsdk-cache
     description: Emscripten cache directory.
-  godot-cpp-directory:
-    default: 'godot-cpp/'
-    description: Location of godot-cpp in the repository. Must not contain relative path signifiers (. or ..). Must be a transparent path part (empty or 'path/to/directory/', ending in a slash).
   gdextension-directory:
     default: ''
     description: Location of the gdextension project within the repository. Must not contain relative path signifiers (. or ..). Must be a transparent path part (empty or 'path/to/directory/', ending in a slash).
@@ -106,16 +103,7 @@ runs:
       with:
         path: |
           ${{ github.workspace }}/${{ inputs.gdextension-directory }}${{ inputs.scons-cache }}
-          ${{ github.workspace }}/${{ inputs.godot-cpp-directory }}${{ inputs.scons-cache }}
         key: ${{ inputs.platform }}_${{ inputs.arch }}_${{ inputs.float-precision }}_${{ inputs.build-target-type }}_cache
-# Build godot-cpp
-    - name: Build godot-cpp Debug Build
-      shell: sh
-      env:
-        SCONS_CACHE: ${{ github.workspace }}/${{ inputs.godot-cpp-directory }}${{ inputs.scons-cache }}
-      run: |
-        scons target=${{ inputs.build-target-type }} platform=${{ inputs.platform }} arch=${{ inputs.arch }} generate_bindings=yes precision=${{ inputs.float-precision }}
-      working-directory: ${{ inputs.godot-cpp-directory }}
 # Build gdextension
     - name: Build GDExtension Debug Build
       shell: sh


### PR DESCRIPTION
Briefly discussed on Rocket Chat, it seems this is wholly just not needed for the runner, as godot-cpp is built as part of the GDExtension build step.

I know some repositories suggest building the deps first and the project later, using separate caches for each such that a rebuild can go faster. But as far as I've seen, in this project it doesn't work because the later build step just re-builds godot-cpp from scratch anyhow (at least for me). If anybody's seen evidence to the contrary, please share them.