### PR TITLE
For the GitHub runner, add scons-arguments and cache-key parameters

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -8,12 +8,20 @@ inputs:
   arch:
     required: true
     description: Target architecture.
+  scons-arguments:
+    default: ''
+    description: Additional space-separated arguments to pass to the scons build command.
+  cache-key:
+    default: ''
+    description: Key to use for caches. This input is used in paths and should not contain POSIX incompatible characters.
   float-precision:
-    default: 'single'
     description: Float precision (single or double).
+    required: false
+    deprecationMessage: Use the scons-arguments (and cache-key) parameters instead. This parameter will continue to work until removed.
   build-target-type:
-    default: 'template_debug'
+    required: false
     description: Build type (template_debug or template_release).
+    deprecationMessage: Use the scons-arguments (and cache-key) parameters instead. This parameter will continue to work until removed.
   scons-cache:
     default: '.scons-cache/'
     description: Scons cache folder name, relative to each scons directory. Must not contain relative path signifiers (. or ..). Must be a transparent path part (empty or 'path/to/directory/', ending in a slash).
@@ -70,7 +78,7 @@ runs:
       uses: mymindstorm/setup-emsdk@v13
       with:
         version: ${{ inputs.em_version }}
-        actions-cache-folder: ${{ inputs.em-cache-directory }}.${{ inputs.float-precision }}.${{ inputs.build-target-type }}
+        actions-cache-folder: ${{ inputs.em-cache-directory }}.${{ inputs.float-precision }}.${{ inputs.build-target-type }}${{ inputs.cache-key }}
     - name: Web - Verify Emscripten setup
       if: ${{ inputs.platform == 'web' }}
       shell: sh
@@ -103,12 +111,12 @@ runs:
       with:
         path: |
           ${{ github.workspace }}/${{ inputs.gdextension-directory }}${{ inputs.scons-cache }}
-        key: ${{ inputs.platform }}_${{ inputs.arch }}_${{ inputs.float-precision }}_${{ inputs.build-target-type }}_cache
+        key: ${{ inputs.platform }}_${{ inputs.arch }}_${{ inputs.float-precision }}_${{ inputs.build-target-type }}${{ inputs.cache-key }}_cache
 # Build gdextension
     - name: Build GDExtension Debug Build
       shell: sh
       env:
         SCONS_CACHE: ${{ github.workspace }}/${{ inputs.gdextension-directory }}${{ inputs.scons-cache }}
       run: |
-        scons target=${{ inputs.build-target-type }} platform=${{ inputs.platform }} arch=${{ inputs.arch }} precision=${{ inputs.float-precision }}
+        scons platform=${{ inputs.platform }} arch=${{ inputs.arch }} ${{ inputs.float-precision && 'precision=' || '' }}${{ inputs.float-precision }} ${{ inputs.build-target-type && 'target=' || '' }}${{ inputs.build-target-type }} ${{ inputs.scons-arguments }}
       working-directory: ${{ inputs.gdextension-directory }}

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -14,247 +14,247 @@ jobs:
         include:
         # Debug templates
           - platform: linux
-            float-precision: single
             arch: x86_64
-            target-type: template_debug
+            scons-arguments: target=template_debug
+            cache-key: .template_debug
             os: ubuntu-20.04
 
           - platform: windows
-            float-precision: single
             arch: x86_32
-            target-type: template_debug
+            scons-arguments: target=template_debug
+            cache-key: .template_debug
             os: windows-latest
 
           - platform: windows
-            float-precision: single
             arch: x86_64
-            target-type: template_debug
+            scons-arguments: target=template_debug
+            cache-key: .template_debug
             os: windows-latest
 
           - platform: macos
-            float-precision: single
             arch: universal
-            target-type: template_debug
+            scons-arguments: target=template_debug
+            cache-key: .template_debug
             os: macos-latest
 
           - platform: android
-            float-precision: single
             arch: arm64
-            target-type: template_debug
+            scons-arguments: target=template_debug
+            cache-key: .template_debug
             os: ubuntu-20.04
 
           - platform: android
-            float-precision: single
             arch: arm32
-            target-type: template_debug
+            scons-arguments: target=template_debug
+            cache-key: .template_debug
             os: ubuntu-20.04
 
           - platform: android
-            float-precision: single
             arch: x86_64
-            target-type: template_debug
+            scons-arguments: target=template_debug
+            cache-key: .template_debug
             os: ubuntu-20.04
 
           - platform: android
-            float-precision: single
             arch: x86_32
-            target-type: template_debug
+            scons-arguments: target=template_debug
+            cache-key: .template_debug
             os: ubuntu-20.04
 
           - platform: ios
-            float-precision: single
             arch: arm64
-            target-type: template_debug
+            scons-arguments: target=template_debug
+            cache-key: .template_debug
             os: macos-latest
 
           - platform: web
-            float-precision: single
             arch: wasm32
-            target-type: template_debug
+            scons-arguments: target=template_debug
+            cache-key: .template_debug
             os: ubuntu-20.04
 
         # Release templates
           - platform: linux
-            float-precision: single
             arch: x86_64
-            target-type: template_release
+            scons-arguments: target=template_release
+            cache-key: .template_release
             os: ubuntu-20.04
 
           # - platform: windows
-          #   float-precision: single
           #   arch: x86_32
-          #   target-type: template_release
+          #   scons-arguments: target=template_release
+          #   cache-key: .template_release
           #   os: windows-latest
 
           # - platform: windows
-          #   float-precision: single
           #   arch: x86_64
-          #   target-type: template_release
+          #   scons-arguments: target=template_release
+          #   cache-key: .template_release
           #   os: windows-latest
 
           # - platform: macos
-          #   float-precision: single
           #   arch: universal
-          #   target-type: template_release
+          #   scons-arguments: target=template_release
+          #   cache-key: .template_release
           #   os: macos-latest
 
           # - platform: android
-          #   float-precision: single
           #   arch: arm64
-          #   target-type: template_release
+          #   scons-arguments: target=template_release
+          #   cache-key: .template_release
           #   os: ubuntu-20.04
 
           # - platform: android
-          #   float-precision: single
           #   arch: arm32
-          #   target-type: template_release
+          #   scons-arguments: target=template_release
+          #   cache-key: .template_release
           #   os: ubuntu-20.04
 
           # - platform: android
-          #   float-precision: single
           #   arch: x86_64
-          #   target-type: template_release
+          #   scons-arguments: target=template_release
+          #   cache-key: .template_release
           #   os: ubuntu-20.04
 
           # - platform: android
-          #   float-precision: single
           #   arch: x86_32
-          #   target-type: template_release
+          #   scons-arguments: target=template_release
+          #   cache-key: .template_release
           #   os: ubuntu-20.04
 
           # - platform: ios
-          #   float-precision: single
           #   arch: arm64
-          #   target-type: template_release
+          #   scons-arguments: target=template_release
+          #   cache-key: .template_release
           #   os: macos-latest
 
           # - platform: web
-          #   float-precision: single
           #   arch: wasm32
-          #   target-type: template_release
+          #   scons-arguments: target=template_release
+          #   cache-key: .template_release
           #   os: ubuntu-20.04
 
         # Double precision templates
         # Double precision debug templates
           - platform: linux
-            float-precision: double
             arch: x86_64
-            target-type: template_debug
+            scons-arguments: precision=double target=template_debug
+            cache-key: .double.template_debug
             os: ubuntu-20.04
 
           - platform: windows
-            float-precision: double
             arch: x86_32
-            target-type: template_debug
+            scons-arguments: precision=double target=template_debug
+            cache-key: .double.template_debug
             os: windows-latest
 
           - platform: windows
-            float-precision: double
             arch: x86_64
-            target-type: template_debug
+            scons-arguments: precision=double target=template_debug
+            cache-key: .double.template_debug
             os: windows-latest
 
           - platform: macos
-            float-precision: double
             arch: universal
-            target-type: template_debug
+            scons-arguments: precision=double target=template_debug
+            cache-key: .double.template_debug
             os: macos-latest
 
           - platform: android
-            float-precision: double
             arch: arm64
-            target-type: template_debug
+            scons-arguments: precision=double target=template_debug
+            cache-key: .double.template_debug
             os: ubuntu-20.04
 
           - platform: android
-            float-precision: double
             arch: arm32
-            target-type: template_debug
+            scons-arguments: precision=double target=template_debug
+            cache-key: .double.template_debug
             os: ubuntu-20.04
 
           - platform: android
-            float-precision: double
             arch: x86_64
-            target-type: template_debug
+            scons-arguments: precision=double target=template_debug
+            cache-key: .double.template_debug
             os: ubuntu-20.04
 
           - platform: android
-            float-precision: double
             arch: x86_32
-            target-type: template_debug
+            scons-arguments: precision=double target=template_debug
+            cache-key: .double.template_debug
             os: ubuntu-20.04
 
           - platform: ios
-            float-precision: double
             arch: arm64
-            target-type: template_debug
+            scons-arguments: precision=double target=template_debug
+            cache-key: .double.template_debug
             os: macos-latest
 
           - platform: web
-            float-precision: double
             arch: wasm32
-            target-type: template_debug
+            scons-arguments: precision=double target=template_debug
+            cache-key: .double.template_debug
             os: ubuntu-20.04
 
         # Double precision release templates
           - platform: linux
-            float-precision: double
             arch: x86_64
-            target-type: template_release
+            scons-arguments: precision=double target=template_release
+            cache-key: .double.template_release
             os: ubuntu-20.04
 
           # - platform: windows
-          #   float-precision: double
           #   arch: x86_32
-          #   target-type: template_release
+          #   scons-arguments: precision=double target=template_release
+          #   cache-key: .double.template_release
           #   os: windows-latest
 
           # - platform: windows
-          #   float-precision: double
           #   arch: x86_64
-          #   target-type: template_release
+          #   scons-arguments: precision=double target=template_release
+          #   cache-key: .double.template_release
           #   os: windows-latest
 
           # - platform: macos
-          #   float-precision: double
           #   arch: universal
-          #   target-type: template_release
+          #   scons-arguments: precision=double target=template_release
+          #   cache-key: .double.template_release
           #   os: macos-latest
 
           # - platform: android
-          #   float-precision: double
           #   arch: arm64
-          #   target-type: template_release
+          #   scons-arguments: precision=double target=template_release
+          #   cache-key: .double.template_release
           #   os: ubuntu-20.04
 
           # - platform: android
-          #   float-precision: double
           #   arch: arm32
-          #   target-type: template_release
+          #   scons-arguments: precision=double target=template_release
+          #   cache-key: .double.template_release
           #   os: ubuntu-20.04
 
           # - platform: android
-          #   float-precision: double
           #   arch: x86_64
-          #   target-type: template_release
+          #   scons-arguments: precision=double target=template_release
+          #   cache-key: .double.template_release
           #   os: ubuntu-20.04
 
           # - platform: android
-          #   float-precision: double
           #   arch: x86_32
-          #   target-type: template_release
+          #   scons-arguments: precision=double target=template_release
+          #   cache-key: .double.template_release
           #   os: ubuntu-20.04
 
           # - platform: ios
-          #   float-precision: double
           #   arch: arm64
-          #   target-type: template_release
+          #   scons-arguments: precision=double target=template_release
+          #   cache-key: .double.template_release
           #   os: macos-latest
 
           # - platform: web
-          #   float-precision: double
           #   arch: wasm32
-          #   target-type: template_release
+          #   scons-arguments: precision=double target=template_release
+          #   cache-key: .double.template_release
           #   os: ubuntu-20.04
     runs-on: ${{ matrix.os }}
     steps:
@@ -279,8 +279,8 @@ jobs:
         with:
           platform: ${{ matrix.platform }}
           arch: ${{ matrix.arch }}
-          float-precision: ${{ matrix.float-precision }}
-          build-target-type: ${{ matrix.target-type }}
+          scons-arguments: ${{ matrix.scons-arguments }}
+          cache-key: ${{ matrix.cache-key }}
 
 # Sign
       - name: Mac Sign
@@ -306,7 +306,7 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: godot-cpp-template-${{ matrix.platform }}-${{ matrix.arch }}-${{ matrix.float-precision }}-${{ matrix.target-type }}
+          name: godot-cpp-template-${{ matrix.platform }}-${{ matrix.arch }}-${{ matrix.cache-key }}
           path: |
             ${{ github.workspace }}/bin/**
 

--- a/README.md
+++ b/README.md
@@ -86,15 +86,8 @@ jobs:
         with:
           platform: ${{ matrix.platform }}
           arch: ${{ matrix.arch }}
-          float-precision: single
-          build-target-type: template_release
-      - name: 🔗 GDExtension Build
-        uses: ./.github/actions/build
-        with:
-          platform: ${{ matrix.platform }}
-          arch: ${{ matrix.arch }}
-          float-precision: ${{ matrix.float-precision }}
-          build-target-type: template_debug
+          scons-arguments: target=template_release
+          cache-key: .template_release
       - name: Mac Sign
         if: ${{ matrix.platform == 'macos' && env.APPLE_CERT_BASE64 }}
         env:
@@ -135,8 +128,8 @@ uses: godotengine/godot-cpp-template/.github/actions/build@main
 with:
   platform: ${{ matrix.platform }}
   arch: ${{ matrix.arch }}
-  float-precision: single
-  build-target-type: template_release
+  scons-arguments: target=template_release
+  cache-key: .template_release
 ```
 with the parameters from the matrix.
 


### PR DESCRIPTION
Also, deprecate float-precision and build-target-type parameters (to be migrated to use scons-arguments instead).

This allows the runner to be used when passing more arguments that aren't covered explicitly, making it more future-proof and compatible with GDExtensions adding their own options.

platform and arch aren't replaced because those parameters are relevant outside the engine, proven by the fact that (at least platform) is used actively as a parameter by the github action.