### PR TITLE
Update setup-emsdk from v13 to v14

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -67,7 +67,7 @@ runs:
 # Web only
     - name: Web - Set up Emscripten latest
       if: ${{ inputs.platform == 'web' }}
-      uses: mymindstorm/setup-emsdk@v13
+      uses: mymindstorm/setup-emsdk@v14
       with:
         version: ${{ inputs.em_version }}
         actions-cache-folder: ${{ inputs.em-cache-directory }}.${{ inputs.float-precision }}.${{ inputs.build-target-type }}


### PR DESCRIPTION
I've been running into issues when multiple runners attempt to use the emsdk cache because the key is the same.
 
This has been addressed in v14: https://github.com/mymindstorm/setup-emsdk/releases/tag/v14

There should be no reason not to upgrade.

Edit: I tested my branch, builds work fine.