### PR TITLE
Refactor SConstruct, and add scu_build option.

### DIFF
--- a/site_scons/site_tools/gdextension.py
+++ b/site_scons/site_tools/gdextension.py
@@ -1,0 +1,40 @@
+import pathlib
+from SCons.Tool import Tool
+
+
+def exists(env):
+    return True
+
+def options(opts):
+    # Add custom options here
+    # opts.Add(
+    #     "custom_option",
+    #     "Custom option help text",
+    #     "default_value"
+    # )
+
+    scu_tool = Tool("scu")
+    scu_tool.options(opts)
+
+def generate(env, godot_cpp_env, sources):
+    scu_tool = Tool("scu")
+
+    # read custom options values
+    # custom_option = env["custom_option"]
+
+    env.Append(CPPPATH=["src/"])
+
+    sources.extend([
+        f for f in env.Glob("src/*.cpp") + env.Glob("src/**/*.cpp")
+        # Generated files will be added selectively and maintained by tools.
+        if not "/gen/" in str(f.path)
+    ])
+
+    scu_tool.generate(env, sources)
+
+    if godot_cpp_env["target"] in ["editor", "template_debug"]:
+        try:
+            doc_data = godot_cpp_env.GodotCPPDocData("src/gen/doc_data.gen.cpp", source=env.Glob("doc_classes/*.xml"))
+            sources.append(doc_data)
+        except AttributeError:
+            print("Not including class reference as we're targeting a pre-4.3 baseline.")

--- a/site_scons/site_tools/scu.py
+++ b/site_scons/site_tools/scu.py
@@ -1,0 +1,31 @@
+import pathlib
+from SCons.Variables import BoolVariable
+
+
+def exists(env):
+    return True
+
+def options(opts):
+    opts.Add(
+        BoolVariable(
+            "scu_build",
+            "Use single compilation unit build.",
+            False
+        )
+    )
+
+def generate(env, sources):
+    if not env.get('scu', False):
+        return
+
+    scu_path = pathlib.Path('src/gen/scu.cpp')
+    scu_path.parent.mkdir(exist_ok=True)
+
+    scu_path.write_text(
+        '\n'.join(
+            f'#include "{pathlib.Path(source.path).relative_to("src")}"'
+            for source in sources
+        ) + '\n'
+    )
+
+    sources[:] = [str(scu_path.absolute())]


### PR DESCRIPTION
The refactor aims to to separate library-specific options from those concerned with the build target. The refactor, in my opinion, makes modifying the template a lot easier, since SConstruct is there to provide an unopinionated framework, while `gdextension.py` can be freely modified to fit the project.

I don't think the new structure is perfect yet, but I do prefer it to the structure we have currently, where SConstruct is kind of difficult to avoid messing up. The new structure roughly mimics the structure of the [godot-cpp SConstruct](https://github.com/godotengine/godot-cpp/blob/master/SConstruct), where most of the actual information is in `godotcpp.py`.

Add single compilation unit tool and option (scu_build). This option mimics godot's own [scu_build option](https://github.com/godotengine/godot/blob/5efd124ca10bf46df62fa2441d80589777e54a5a/SConstruct#L270): It compiles the whole project as a single cpp file. This can improve binary size and speed, if supported by the project.

Finally, there is a change to how `localEnv` is handled: Any options or modifications applied to the `gdextension` env now do not affect `godot-cpp` (unless specified explicitly). For example, in my own project I compile with `-DXTENSOR_USE_XSIMD`. This used to be passed to all godot-cpp files too, which is of course nonsense. By cloning the godot-cpp env, you can modify the new env without affecting godot-cpp compilation.