### PR TITLE
Use matrix notation in build.yml to reduce clutter and update Ubuntu image

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -10,252 +10,34 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-        # Debug templates
-          - platform: linux
-            float-precision: single
-            arch: x86_64
-            target-type: template_debug
-            os: ubuntu-20.04
-
-          - platform: windows
-            float-precision: single
-            arch: x86_32
-            target-type: template_debug
-            os: windows-latest
-
-          - platform: windows
-            float-precision: single
-            arch: x86_64
-            target-type: template_debug
-            os: windows-latest
-
-          - platform: macos
-            float-precision: single
-            arch: universal
-            target-type: template_debug
-            os: macos-latest
-
-          - platform: android
-            float-precision: single
-            arch: arm64
-            target-type: template_debug
-            os: ubuntu-20.04
-
-          - platform: android
-            float-precision: single
-            arch: arm32
-            target-type: template_debug
-            os: ubuntu-20.04
-
-          - platform: android
-            float-precision: single
-            arch: x86_64
-            target-type: template_debug
-            os: ubuntu-20.04
-
-          - platform: android
-            float-precision: single
-            arch: x86_32
-            target-type: template_debug
-            os: ubuntu-20.04
-
-          - platform: ios
-            float-precision: single
-            arch: arm64
-            target-type: template_debug
-            os: macos-latest
-
-          - platform: web
-            float-precision: single
-            arch: wasm32
-            target-type: template_debug
-            os: ubuntu-20.04
-
-        # Release templates
-          - platform: linux
-            float-precision: single
-            arch: x86_64
+        # A build is made for every possible combination of parameters
+        # You can add or remove entries from the arrays of each parameter to custimize which builds you want to run
+        # See https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/running-variations-of-jobs-in-a-workflow
+        target:
+          [
+            { platform: linux, arch: x86_64, os: ubuntu-22.04 },
+            { platform: windows, arch: x86_64, os: windows-latest },
+            { platform: windows, arch: x86_32, os: windows-latest },
+            { platform: macos, arch: universal, os: macos-latest },
+            { platform: android, arch: arm64, os: ubuntu-22.04 },
+            { platform: android, arch: arm32, os: ubuntu-22.04 },
+            { platform: android, arch: x86_64, os: ubuntu-22.04 },
+            { platform: android, arch: x86_32, os: ubuntu-22.04 },
+            { platform: ios, arch: arm64, os: macos-latest },
+            { platform: web, arch: wasm32, os: ubuntu-22.04 }
+          ]
+        target-type: [template_debug]
+        float-precision: [single, double]
+        include: # Also build a release version for these specific targets. Remove if you add template_release above.
+          - target: { platform: linux, arch: x86_64, os: ubuntu-22.04 }
             target-type: template_release
-            os: ubuntu-20.04
+            float-precision: single
 
-          # - platform: windows
-          #   float-precision: single
-          #   arch: x86_32
-          #   target-type: template_release
-          #   os: windows-latest
-
-          # - platform: windows
-          #   float-precision: single
-          #   arch: x86_64
-          #   target-type: template_release
-          #   os: windows-latest
-
-          # - platform: macos
-          #   float-precision: single
-          #   arch: universal
-          #   target-type: template_release
-          #   os: macos-latest
-
-          # - platform: android
-          #   float-precision: single
-          #   arch: arm64
-          #   target-type: template_release
-          #   os: ubuntu-20.04
-
-          # - platform: android
-          #   float-precision: single
-          #   arch: arm32
-          #   target-type: template_release
-          #   os: ubuntu-20.04
-
-          # - platform: android
-          #   float-precision: single
-          #   arch: x86_64
-          #   target-type: template_release
-          #   os: ubuntu-20.04
-
-          # - platform: android
-          #   float-precision: single
-          #   arch: x86_32
-          #   target-type: template_release
-          #   os: ubuntu-20.04
-
-          # - platform: ios
-          #   float-precision: single
-          #   arch: arm64
-          #   target-type: template_release
-          #   os: macos-latest
-
-          # - platform: web
-          #   float-precision: single
-          #   arch: wasm32
-          #   target-type: template_release
-          #   os: ubuntu-20.04
-
-        # Double precision templates
-        # Double precision debug templates
-          - platform: linux
-            float-precision: double
-            arch: x86_64
-            target-type: template_debug
-            os: ubuntu-20.04
-
-          - platform: windows
-            float-precision: double
-            arch: x86_32
-            target-type: template_debug
-            os: windows-latest
-
-          - platform: windows
-            float-precision: double
-            arch: x86_64
-            target-type: template_debug
-            os: windows-latest
-
-          - platform: macos
-            float-precision: double
-            arch: universal
-            target-type: template_debug
-            os: macos-latest
-
-          - platform: android
-            float-precision: double
-            arch: arm64
-            target-type: template_debug
-            os: ubuntu-20.04
-
-          - platform: android
-            float-precision: double
-            arch: arm32
-            target-type: template_debug
-            os: ubuntu-20.04
-
-          - platform: android
-            float-precision: double
-            arch: x86_64
-            target-type: template_debug
-            os: ubuntu-20.04
-
-          - platform: android
-            float-precision: double
-            arch: x86_32
-            target-type: template_debug
-            os: ubuntu-20.04
-
-          - platform: ios
-            float-precision: double
-            arch: arm64
-            target-type: template_debug
-            os: macos-latest
-
-          - platform: web
-            float-precision: double
-            arch: wasm32
-            target-type: template_debug
-            os: ubuntu-20.04
-
-        # Double precision release templates
-          - platform: linux
-            float-precision: double
-            arch: x86_64
+          - target: { platform: linux, arch: x86_64, os: ubuntu-22.04 }
             target-type: template_release
-            os: ubuntu-20.04
+            float-precision: double
 
-          # - platform: windows
-          #   float-precision: double
-          #   arch: x86_32
-          #   target-type: template_release
-          #   os: windows-latest
-
-          # - platform: windows
-          #   float-precision: double
-          #   arch: x86_64
-          #   target-type: template_release
-          #   os: windows-latest
-
-          # - platform: macos
-          #   float-precision: double
-          #   arch: universal
-          #   target-type: template_release
-          #   os: macos-latest
-
-          # - platform: android
-          #   float-precision: double
-          #   arch: arm64
-          #   target-type: template_release
-          #   os: ubuntu-20.04
-
-          # - platform: android
-          #   float-precision: double
-          #   arch: arm32
-          #   target-type: template_release
-          #   os: ubuntu-20.04
-
-          # - platform: android
-          #   float-precision: double
-          #   arch: x86_64
-          #   target-type: template_release
-          #   os: ubuntu-20.04
-
-          # - platform: android
-          #   float-precision: double
-          #   arch: x86_32
-          #   target-type: template_release
-          #   os: ubuntu-20.04
-
-          # - platform: ios
-          #   float-precision: double
-          #   arch: arm64
-          #   target-type: template_release
-          #   os: macos-latest
-
-          # - platform: web
-          #   float-precision: double
-          #   arch: wasm32
-          #   target-type: template_release
-          #   os: ubuntu-20.04
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.target.os }}
     steps:
       # Clone this repository
       - name: Checkout
@@ -277,7 +59,7 @@ jobs:
       - name: Setup godot-cpp
         uses: ./godot-cpp/.github/actions/setup-godot-cpp
         with:
-          platform: ${{ matrix.platform }}
+          platform: ${{ matrix.target.platform }}
           em-version: 3.1.62
 
       # Build GDExtension (with caches)
@@ -285,18 +67,18 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/.scons-cache/
-          key: ${{ matrix.platform }}_${{ matrix.arch }}_${{ matrix.float-precision }}_${{ matrix.target-type }}_cache
+          key: ${{ matrix.target.platform }}_${{ matrix.target.arch }}_${{ matrix.float-precision }}_${{ matrix.target-type }}_cache
       - name: Build GDExtension Debug Build
         shell: sh
         env:
           SCONS_CACHE: ${{ github.workspace }}/.scons-cache/
         run: |
-          scons target=${{ matrix.target-type }} platform=${{ matrix.platform }} arch=${{ matrix.arch }} precision=${{ matrix.float-precision }}
+          scons target=${{ matrix.target-type }} platform=${{ matrix.target.platform }} arch=${{ matrix.target.arch }} precision=${{ matrix.float-precision }}
 
       # Sign the binary (macOS only)
       - name: Mac Sign
         # Disable sign if secrets are not set
-        if: ${{ matrix.platform == 'macos' && env.APPLE_CERT_BASE64 }}
+        if: ${{ matrix.target.platform == 'macos' && env.APPLE_CERT_BASE64 }}
         env:
           APPLE_CERT_BASE64: ${{ secrets.APPLE_CERT_BASE64 }}
         uses: ./.github/actions/sign
@@ -311,7 +93,7 @@ jobs:
 
       # Clean up compilation files
       - name: Windows - Delete compilation files
-        if: ${{ matrix.platform == 'windows' }}
+        if: ${{ matrix.target.platform == 'windows' }}
         shell: pwsh
         run: |
           Remove-Item bin/* -Include *.exp,*.lib,*.pdb -Force
@@ -320,14 +102,14 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: godot-cpp-template-${{ matrix.platform }}-${{ matrix.arch }}-${{ matrix.float-precision }}-${{ matrix.target-type }}
+          name: godot-cpp-template-${{ matrix.target.platform }}-${{ matrix.target.arch }}-${{ matrix.float-precision }}-${{ matrix.target-type }}
           path: |
             ${{ github.workspace }}/bin/**
 
   # Merges all the build artifacts together into a single godot-cpp-template artifact.
   # If you comment out this step, all the builds will be uploaded individually.
   merge:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: build
     steps:
       - name: Merge Artifacts


### PR DESCRIPTION
Instead of having a code block for every possible build combination this PR uses the proper matrix notation to reduce the length of the file and improve readability. I made sure to not change the actual configuration of builds that are being produced. Though I'm not sure why its setup to run all the `double` builds since those aren't linked to in the `.gdextension` file.

```yml
# ...

          - platform: linux
            float-precision: single
            arch: x86_64
            target-type: template_debug
            os: ubuntu-20.04

          - platform: windows
            float-precision: single
            arch: x86_32
            target-type: template_debug
            os: windows-latest

          - platform: windows
            float-precision: single
            arch: x86_64
            target-type: template_debug
            os: windows-latest

# ... way more
```

becomes

```yml
        target:
          [
            { platform: linux, arch: x86_64, os: ubuntu-24.04 },
            { platform: windows, arch: x86_64, os: windows-latest },
            { platform: windows, arch: x86_32, os: windows-latest },
            { platform: macos, arch: universal, os: macos-latest },
            { platform: ios, arch: arm64, os: macos-latest },
            { platform: android, arch: arm64, os: ubuntu-24.04 },
            { platform: android, arch: arm32, os: ubuntu-24.04 },
            { platform: android, arch: x86_64, os: ubuntu-24.04 },
            { platform: android, arch: x86_32, os: ubuntu-24.04 },
            { platform: web, arch: wasm32, os: ubuntu-24.04 },
          ]
```



I also updated the version of the Ubuntu runner image since its getting deprecated. https://github.com/actions/runner-images/issues/11101