### PR TITLE
Include env["suffix"] in binary names for macOS and iOS

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -50,7 +50,7 @@ filepath = ""
 
 if env["platform"] == "macos" or env["platform"] == "ios":
     filepath = "{}.framework/".format(env["platform"])
-    file = "{}.{}.{}".format(libname, env["platform"], env["target"])
+    file = "{}{}".format(libname, env["suffix"])
 
 libraryfile = "bin/{}/{}{}".format(env["platform"], filepath, file)
 library = env.SharedLibrary(

--- a/bin/ios/ios.framework/Info.plist
+++ b/bin/ios/ios.framework/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>
-	<string>libEXTENSION-NAME.macos.template_release</string>
+	<string>libEXTENSION-NAME.ios.template_release.universal</string>
 	<key>CFBundleName</key>
 	<string>Godot Template Cpp</string>
 	<key>CFBundleDisplayName</key>

--- a/bin/macos/macos.framework/Resources/Info.plist
+++ b/bin/macos/macos.framework/Resources/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>
-	<string>libEXTENSION-NAME.macos.template_release</string>
+	<string>libEXTENSION-NAME.macos.template_release.universal</string>
 	<key>CFBundleName</key>
 	<string>Godot Cpp Template</string>
 	<key>CFBundleDisplayName</key>

--- a/demo/bin/example.gdextension
+++ b/demo/bin/example.gdextension
@@ -5,10 +5,10 @@ compatibility_minimum = "4.1"
 
 [libraries]
 ; Relative paths ensure that our GDExtension can be placed anywhere in the project directory.
-macos.debug = "./macos/macos.framework/libEXTENSION-NAME.macos.template_debug"
-macos.release = "./macos/macos.framework/libEXTENSION-NAME.macos.template_release"
-ios.debug = "./ios/ios.framework/libEXTENSION-NAME.ios.template_debug"
-ios.release = "./ios/ios.framework/libEXTENSION-NAME.ios.template_release"
+macos.debug = "./macos/macos.framework/libEXTENSION-NAME.macos.template_debug.universal"
+macos.release = "./macos/macos.framework/libEXTENSION-NAME.macos.template_release.universal"
+ios.debug = "./ios/ios.framework/libEXTENSION-NAME.ios.template_debug.universal"
+ios.release = "./ios/ios.framework/libEXTENSION-NAME.ios.template_release.universal"
 windows.debug.x86_32 = "./windows/libEXTENSION-NAME.windows.template_debug.x86_32.dll"
 windows.release.x86_32 = "./windows/libEXTENSION-NAME.windows.template_release.x86_32.dll"
 windows.debug.x86_64 = "./windows/libEXTENSION-NAME.windows.template_debug.x86_64.dll"


### PR DESCRIPTION
Fixes #76

This adds the whole suffix instead of just the platform and target to the binary names.

https://github.com/godotengine/godot-cpp-template/blob/3b48c096840568cdd8dee94c6d0330a850d618fc/SConstruct#L51-L53

Here is the effect on the file names for macOS:

Before:
```
Resources
libEXTENSION-NAME.macos.template_debug
```
After:
```
Resources
libEXTENSION-NAME.macos.template_debug.double.universal
libEXTENSION-NAME.macos.template_debug.universal
```

Requires adjustment to `Info.plist` files.

Also fixes the `CFBundleExecutable` pointing to a macOS framework for iOS. https://github.com/godotengine/godot-cpp-template/commit/3b48c096840568cdd8dee94c6d0330a850d618fc#diff-38bc16d5822bfc5e55a99774078b8f4612d6936342a53059e42ee74bd5fd0661R10
