### PR TITLE
CI: Use caching actions from godot-cpp

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -63,17 +63,25 @@ jobs:
           em-version: 3.1.62
 
       # Build GDExtension (with caches)
-      - name: Cache .scons_cache
-        uses: actions/cache@v4
+
+      - name: Restore .scons_cache
+        uses: ./godot-cpp/.github/actions/godot-cache-restore
         with:
-          path: ${{ github.workspace }}/.scons-cache/
-          key: ${{ matrix.target.platform }}_${{ matrix.target.arch }}_${{ matrix.float-precision }}_${{ matrix.target-type }}_cache
+          scons-cache: ${{ github.workspace }}/.scons-cache/
+          cache-name: ${{ matrix.target.platform }}_${{ matrix.target.arch }}_${{ matrix.float-precision }}_${{ matrix.target-type }}
+
       - name: Build GDExtension Debug Build
         shell: sh
         env:
           SCONS_CACHE: ${{ github.workspace }}/.scons-cache/
         run: |
           scons target=${{ matrix.target-type }} platform=${{ matrix.target.platform }} arch=${{ matrix.target.arch }} precision=${{ matrix.float-precision }}
+
+      - name: Save .scons_cache
+        uses: ./godot-cpp/.github/actions/godot-cache-save
+        with:
+          scons-cache: ${{ github.workspace }}/.scons-cache/
+          cache-name: ${{ matrix.target.platform }}_${{ matrix.target.arch }}_${{ matrix.float-precision }}_${{ matrix.target-type }}
 
       # Sign the binary (macOS only)
       - name: Mac Sign


### PR DESCRIPTION
This PR switches out the existing cache step with the [`godot-cache-restore`](https://github.com/godotengine/godot-cpp/blob/f3a1a2fd458dfaf4de08c906f22a2fe9e924b16f/.github/actions/godot-cache-restore/action.yml) and [`godot-cache-save`](https://github.com/godotengine/godot-cpp/blob/f3a1a2fd458dfaf4de08c906f22a2fe9e924b16f/.github/actions/godot-cache-save/action.yml) actions from godot-cpp. These actions have a different scheme for the cache keys. They create a new cache for every commit by appending - among other things - the commit SHA, but restore from any key that matches up until the unique identifier. Using this approach fixes the caches not being updatable.

A few notes:
- GODOT_BASE_BRANCH doesn't seem to be set, so there is one empty part. Where is this set normally?
- I dropped the "_cache" suffix because that's unnecessary

