### PR TITLE
CI: Use MinGW for Windows builds

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -73,7 +73,7 @@ jobs:
         env:
           SCONS_CACHE: ${{ github.workspace }}/.scons-cache/
         run: |
-          scons use_mingw=yes target=${{ matrix.target-type }} platform=${{ matrix.target.platform }} arch=${{ matrix.target.arch }} precision=${{ matrix.float-precision }}
+          scons lto=auto use_mingw=yes target=${{ matrix.target-type }} platform=${{ matrix.target.platform }} arch=${{ matrix.target.arch }} precision=${{ matrix.float-precision }}
 
       # Sign the binary (macOS only)
       - name: Mac Sign

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -73,7 +73,7 @@ jobs:
         env:
           SCONS_CACHE: ${{ github.workspace }}/.scons-cache/
         run: |
-          scons target=${{ matrix.target-type }} platform=${{ matrix.target.platform }} arch=${{ matrix.target.arch }} precision=${{ matrix.float-precision }}
+          scons use_mingw=yes target=${{ matrix.target-type }} platform=${{ matrix.target.platform }} arch=${{ matrix.target.arch }} precision=${{ matrix.float-precision }}
 
       # Sign the binary (macOS only)
       - name: Mac Sign


### PR DESCRIPTION
Currently the setup-godot-cpp actions install MinGW but then the scons command doesn't have `use_mingw=yes` set. This seems like a waste of time. At the last meeting we agreed that it would be a better idea to switch from MSVC to MinGW since binaries are said to have better performance and Link Time Optimizations can be enabled.

Just `use_mingw=yes` works but with `lto=auto` it fails.. Can someone diagnose this?