### PR TITLE
Add an example for using a build profile

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -10,6 +10,14 @@ projectdir = "demo"
 
 localEnv = Environment(tools=["default"], PLATFORM="")
 
+# Build profiles can be used to decrease compile times.
+# You can either specify "disabled_classes", OR
+# explicitly specify "enabled_classes" which disables all other classes.
+# Modify the example file as needed and uncomment the line below or
+# manually specify the build_profile parameter when running SCons.
+
+# localEnv["build_profile"] = "build_profile.json"
+
 customs = ["custom.py"]
 customs = [os.path.abspath(path) for path in customs]
 

--- a/build_profile.json
+++ b/build_profile.json
@@ -1,0 +1,9 @@
+{
+	"_": "This is an example build profile and not used by default. See the SConstruct file for more information.",
+	"type": "feature_profile",
+	"enabled_classes": [
+		"Node3D",
+		"ImageTexture",
+		"OS"
+	]
+}


### PR DESCRIPTION
I suggest adding this file to hint at the fact that doing this is possible. Disabling unused classes can save a lot of time when compiling godot-cpp.

The included build profile has some example classes enabled. To make use of the feature, a user would discover the file, read the comment in the SConstruct, adjust the profile and uncomment the instruction.