### PR TITLE
Add an example class to the project.

### DIFF
--- a/demo/example.gd
+++ b/demo/example.gd
@@ -1,0 +1,6 @@
+extends Node
+
+
+func _ready() -> void:
+	var example := ExampleClass.new()
+	example.print_type(example)

--- a/demo/example.tscn
+++ b/demo/example.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://dh0oj81pufivs"]
+
+[ext_resource type="Script" path="res://example.gd" id="1_jdh55"]
+
+[node name="Node" type="Node"]
+script = ExtResource("1_jdh55")

--- a/doc_classes/ExampleClass.xml
+++ b/doc_classes/ExampleClass.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="ExampleClass" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
+	<brief_description>
+		Example class.
+	</brief_description>
+	<description>
+		An example class.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="print_type" qualifiers="const">
+			<return type="void" />
+			<param index="0" name="variant" type="Variant" />
+			<description>
+				Print the type of the variant.
+			</description>
+		</method>
+	</methods>
+</class>

--- a/src/example_class.cpp
+++ b/src/example_class.cpp
@@ -1,0 +1,9 @@
+#include "example_class.h"
+
+void ExampleClass::_bind_methods() {
+	godot::ClassDB::bind_method(D_METHOD("print_type", "variant"), &ExampleClass::print_type);
+}
+
+void ExampleClass::print_type(const Variant &p_variant) const {
+	print_line(vformat("Type: %d", p_variant.get_type()));
+}

--- a/src/example_class.h
+++ b/src/example_class.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "godot_cpp/classes/ref_counted.hpp"
+#include "godot_cpp/classes/wrapped.hpp"
+#include "godot_cpp/variant/variant.hpp"
+
+using namespace godot;
+
+class ExampleClass : public RefCounted {
+	GDCLASS(ExampleClass, RefCounted)
+
+protected:
+	static void _bind_methods();
+
+public:
+	ExampleClass() = default;
+	~ExampleClass() override = default;
+
+	void print_type(const Variant &p_variant) const;
+};

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -1,8 +1,11 @@
 #include "register_types.h"
+
 #include <gdextension_interface.h>
 #include <godot_cpp/core/class_db.hpp>
 #include <godot_cpp/core/defs.hpp>
 #include <godot_cpp/godot.hpp>
+
+#include "example_class.h"
 
 using namespace godot;
 
@@ -11,7 +14,7 @@ void initialize_gdextension_types(ModuleInitializationLevel p_level)
 	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
 		return;
 	}
-	//GDREGISTER_CLASS(YourClass);
+	GDREGISTER_CLASS(ExampleClass);
 }
 
 void uninitialize_gdextension_types(ModuleInitializationLevel p_level) {


### PR DESCRIPTION
When you first clone `godot-cpp-template`, you may still have no idea what to do next, because the gdextension doesn't actually do anything right now. This may be additionally confusing because you may not know how to check your GDExtension is even loading.
While the docs explain how to create and register classes, people may not look there when starting a project. It's may be easier to have some boilerplate for it ready and get right to programming C++.

This PR adds a minimal class for example purposes. I don't think we should try to cover a lot of functionality with it, but a single registered function and some docs is probably enough for people to kick off their project from.