### PR TITLE
Improve workflow architectures

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -11,31 +11,27 @@ jobs:
       fail-fast: false
       matrix:
         # A build is made for every possible combination of parameters
-        # You can add or remove entries from the arrays of each parameter to custimize which builds you want to run
+        # You can add or remove entries from the arrays of each parameter to customize which builds you want to run
         # See https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/running-variations-of-jobs-in-a-workflow
         target:
           [
             { platform: linux, arch: x86_64, os: ubuntu-22.04 },
+            { platform: linux, arch: x86_32, os: ubuntu-22.04 },
+            { platform: linux, arch: arm64, os: ubuntu-22.04-arm },
+            { platform: linux, arch: arm32, os: ubuntu-22.04-arm },
             { platform: windows, arch: x86_64, os: windows-latest },
             { platform: windows, arch: x86_32, os: windows-latest },
+            { platform: windows, arch: arm64, os: windows-latest },
             { platform: macos, arch: universal, os: macos-latest },
-            { platform: android, arch: arm64, os: ubuntu-22.04 },
-            { platform: android, arch: arm32, os: ubuntu-22.04 },
             { platform: android, arch: x86_64, os: ubuntu-22.04 },
             { platform: android, arch: x86_32, os: ubuntu-22.04 },
+            { platform: android, arch: arm64, os: ubuntu-22.04 },
+            { platform: android, arch: arm32, os: ubuntu-22.04 },
             { platform: ios, arch: arm64, os: macos-latest },
-            { platform: web, arch: wasm32, os: ubuntu-22.04 }
+            { platform: web, arch: wasm32, os: ubuntu-22.04 },
           ]
-        target-type: [template_debug]
+        target-type: [template_debug, template_release]
         float-precision: [single, double]
-        include: # Also build a release version for these specific targets. Remove if you add template_release above.
-          - target: { platform: linux, arch: x86_64, os: ubuntu-22.04 }
-            target-type: template_release
-            float-precision: single
-
-          - target: { platform: linux, arch: x86_64, os: ubuntu-22.04 }
-            target-type: template_release
-            float-precision: double
 
     runs-on: ${{ matrix.target.os }}
     steps:
@@ -54,6 +50,12 @@ jobs:
       #  shell: bash
       #  run: |
       #    clang-format src/** --dry-run --Werror
+
+      # Add linux x86_32 toolchain
+      - name: Install multilib support
+        if: ${{ matrix.target.platform == 'linux' && matrix.target.arch == 'x86_32' }}
+        run: |
+          sudo apt-get update && sudo apt-get install -y gcc-multilib g++-multilib
 
       # Setup dependencies
       - name: Setup godot-cpp


### PR DESCRIPTION
Fixes #88:
- Adds `linux x86_32`, `linux arm64`, `linux arm32`, `windows arm64`, `template_release` for non-`linux` builds
- Rearranges builds for consistency
- Fixes spelling error
- Adds trailing comma to make it easier to add new items

I chose the architectures from the "all downloads" dropdown available at [Godot 4.4.1-stable](https://godotengine.org/download/archive/4.4.1-stable).

Notes from my research:
- Windows does not support `arm32`.
- iOS does not support `x86_64` or `x86_32`, and does not use `arm32` since iPhone 5 (2012).
- `wasm64` exists but is experimental and not supported by the compiler.

**Possible issues:**
I have been having issues with `linux x86_32` and `linux arm64` in my personal project:

I get this error with `x86_32`:
```
Compiling godot-cpp/src/core/memory.cpp ...
In file included from godot-cpp/include/godot_cpp/core/memory.hpp:34,
                 from godot-cpp/src/core/memory.cpp:31:
/usr/include/c++/11/cstddef:49:10: fatal error: bits/c++config.h: No such file or directory
   49 | #include <bits/c++config.h>
      |          ^~~~~~~~~~~~~~~~~~
compilation terminated.
```
This StackOverflow question seems to match: https://stackoverflow.com/questions/4643197/missing-include-bits-cconfig-h-when-cross-compiling-64-bit-program-on-32-bit

I get this error with `arm64`:
```
Compiling godot-cpp/src/core/memory.cpp ...
cc1plus: error: bad value ('armv8-a') for '-march=' switch
cc1plus: note: valid arguments to '-march=' switch are: nocona core2 nehalem corei7 westmere sandybridge corei7-avx ivybridge core-avx-i haswell core-avx2 broadwell skylake skylake-avx512 cannonlake icelake-client rocketlake icelake-server cascadelake tigerlake cooperlake sapphirerapids alderlake bonnell atom silvermont slm goldmont goldmont-plus tremont knl knm x86-64 x86-64-v2 x86-64-v3 x86-64-v4 eden-x2 nano nano-1000 nano-[20](https://github.com/jsonh-org/JsonhGdextension/actions/runs/14551688442/job/40823637458#step:5:21)00 nano-3000 nano-x2 eden-x4 nano-x4 k8 k8-sse3 opteron opteron-sse3 athlon64 athlon64-sse3 athlon-fx amdfam10 barcelona bdver1 bdver2 bdver3 bdver4 znver1 znver2 znver3 btver1 btver2 native
```
This StackOverflow question seems to match: https://stackoverflow.com/questions/40142803/cc1-error-bad-value-armv8-a-for-march-switch