### PR TITLE
Add section about LSP support by compiledb scons command

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,17 @@ For getting started after cloning your own copy to your local machine, you shoul
 * change the `entry_symbol` string inside your `demo/bin/your-extension.gdextension` file to be configured for your GDExtension name. This should be the same as the `GDExtensionBool GDE_EXPORT` external C function. As the name suggests, this sets the entry function for your GDExtension to be loaded by the Godot editors C API.
 * register the classes you want Godot to interact with inside the `register_types.cpp` file in the initialization method (here `initialize_gdextension_types`) in the syntax `GDREGISTER_CLASS(CLASS-NAME);`.
 
+### Configuring an IDE 
+You can develop your own extension with any text editor and by invoking scons on the command line, but if you want to work with an IDE (Integrated Development Environment), you can use a compilation database file called `compile_commands.json`. Most IDEs should automatically identify this file, and self-configure appropriately.
+To generate the database file, you can run one of the following commands in the project root directory:
+```shell
+# Generate compile_commands.json while compiling
+scons compiledb=yes
+
+# Generate compile_commands.json without compiling
+scons compiledb=yes compile_commands.json
+```
+
 ## Usage - Actions
 
 This repository comes with a GitHub action that builds the GDExtension for cross-platform use. It triggers automatically for each pushed change. You can find and edit it in [builds.yml](.github/workflows/builds.yml).


### PR DESCRIPTION
Supersedes https://github.com/godotengine/godot-cpp-template/pull/91

Adds a section explaining that a compilation database can be compiled using scons to enable IDE features like autocomplete and more.