### PR TITLE
Add subdirectories to source file collection logic in SConstruct (reverted)

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -38,7 +38,11 @@ Run the following command to download godot-cpp:
 env = SConscript("godot-cpp/SConstruct", {"env": env, "customs": customs})
 
 env.Append(CPPPATH=["src/"])
+
 sources = Glob("src/*.cpp")
+sources.extend(Glob("src/*/*.cpp"))
+sources.extend(Glob("src/*/*/*.cpp"))
+sources.extend(Glob("src/*/*/*/*.cpp"))
 
 if env["target"] in ["editor", "template_debug"]:
     try:


### PR DESCRIPTION
This adds sub-directory detection when gathering sources for SConstruct, it took me a while to figure out why using subfolders in my src folder wasn't working for me to realize that Glob simply does not look at subfolders. 

I think this would improve the template for people who want to use it for a serious project as I find it very unlikely that anyone would put all their files on the root src/ folder for anything remotely big