### PR TITLE
Split CI from build actions, since they're for pretty different use-cases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,88 @@
+# For syntax, see https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax
+# This workflow is automatically triggered for every push and pull request, to verify that everything still builds.
+
+name: Continuous Integration
+on:
+  workflow_call:
+  push:
+  pull_request:
+  merge_group:
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        # Test a few selected combinations of parameters ("test case matrix").
+        # While it would be nice to test all needed combinations, in practice this would a waste of CI usage time.
+        # By building just with a few combinations, we only need a few runners,
+        # while still achieving adequate coverage.
+        # To make a full build with all combinations, use the make_build.yml workflow instead.
+        include:
+          - target: { platform: linux, arch: x86_64, os: ubuntu-22.04 }
+            target-type: template_debug
+            float-precision: double
+          - target: { platform: windows, arch: x86_64, os: windows-latest }
+            target-type: template_release
+            float-precision: single
+          - target: { platform: macos, arch: universal, os: macos-latest }
+            target-type: template_debug
+            float-precision: single
+          - target: { platform: android, arch: arm64, os: ubuntu-22.04 }
+            target-type: template_debug
+            float-precision: single
+          - target: { platform: web, arch: wasm32, os: ubuntu-22.04 }
+            target-type: template_release
+            float-precision: double
+
+    runs-on: ${{ matrix.target.os }}
+    steps:
+      # Clone this repository
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      # Lint
+      #- name: Setup clang-format
+      #  shell: bash
+      #  run: |
+      #    python -m pip install clang-format
+      #- name: Run clang-format
+      #  shell: bash
+      #  run: |
+      #    clang-format src/** --dry-run --Werror
+
+      # Add linux x86_32 toolchain
+      - name: Install multilib support
+        if: ${{ matrix.target.platform == 'linux' && matrix.target.arch == 'x86_32' }}
+        run: |
+          sudo apt-get update && sudo apt-get install -y gcc-multilib g++-multilib
+
+      # Setup dependencies
+      - name: Setup godot-cpp
+        uses: ./godot-cpp/.github/actions/setup-godot-cpp
+        with:
+          platform: ${{ matrix.target.platform }}
+          em-version: 3.1.62
+
+      # Build GDExtension (with caches)
+
+      - name: Restore .scons_cache
+        uses: ./godot-cpp/.github/actions/godot-cache-restore
+        with:
+          scons-cache: ${{ github.workspace }}/.scons-cache/
+          cache-name: ${{ matrix.target.platform }}_${{ matrix.target.arch }}_${{ matrix.float-precision }}_${{ matrix.target-type }}
+
+      - name: Build GDExtension Debug Build
+        shell: sh
+        env:
+          SCONS_CACHE: ${{ github.workspace }}/.scons-cache/
+        run: |
+          scons target=${{ matrix.target-type }} platform=${{ matrix.target.platform }} arch=${{ matrix.target.arch }} precision=${{ matrix.float-precision }}
+
+      - name: Save .scons_cache
+        uses: ./godot-cpp/.github/actions/godot-cache-save
+        with:
+          scons-cache: ${{ github.workspace }}/.scons-cache/
+          cache-name: ${{ matrix.target.platform }}_${{ matrix.target.arch }}_${{ matrix.float-precision }}_${{ matrix.target-type }}

--- a/.github/workflows/make_build.yml
+++ b/.github/workflows/make_build.yml
@@ -1,9 +1,9 @@
-name: Build GDExtension
+# For syntax, see https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax
+# This workflow is triggered manually on the "Actions" tab on GitHub, and can be used to create releases.
+
+name: Make a GDExtension build for all supported platforms
 on:
-  workflow_call:
-  push:
-  pull_request:
-  merge_group:
+  workflow_dispatch:
 
 jobs:
   build:
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         # A build is made for every possible combination of parameters
-        # You can add or remove entries from the arrays of each parameter to customize which builds you want to run
+        # You can add or remove entries from the arrays of each parameter to customize which builds you want to run.
         # See https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/running-variations-of-jobs-in-a-workflow
         target:
           [
@@ -31,7 +31,7 @@ jobs:
             { platform: web, arch: wasm32, os: ubuntu-22.04 },
           ]
         target-type: [template_debug, template_release]
-        float-precision: [single, double]
+        float-precision: [single]
 
     runs-on: ${{ matrix.target.os }}
     steps:
@@ -40,16 +40,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
-
-      # Lint
-      #- name: Setup clang-format
-      #  shell: bash
-      #  run: |
-      #    python -m pip install clang-format
-      #- name: Run clang-format
-      #  shell: bash
-      #  run: |
-      #    clang-format src/** --dry-run --Werror
 
       # Add linux x86_32 toolchain
       - name: Install multilib support

--- a/README.md
+++ b/README.md
@@ -36,5 +36,9 @@ scons compiledb=yes compile_commands.json
 
 ## Usage - Actions
 
-This repository comes with a GitHub action that builds the GDExtension for cross-platform use. It triggers automatically for each pushed change. You can find and edit it in [builds.yml](.github/workflows/builds.yml).
-After a workflow run is complete, you can find the file `godot-cpp-template.zip` on the `Actions` tab on GitHub.
+This repository comes with continuous integration (CI) through a GitHub action that tests building the GDExtension.
+It triggers automatically for each pushed change. You can find and edit it in [builds.yml](.github/workflows/ci.yml).
+
+There is also a workflow ([make_build.yml](.github/workflows/make_build.yml)) that builds the GDExtension for all supported platforms that you can use to create releases.
+You can trigger this workflow manually from the `Actions` tab on GitHub.
+After it is complete, you can find the file `godot-cpp-template.zip` in the `Artifacts` section of the workflow run.


### PR DESCRIPTION
- Alternative to / supersedes #93 

There are two different use-cases for GitHub actions in this repository:
- Use as CI / testing for mistakes
- Making a build

The two aren't very compatible, because CI should be quick and minimal, while making builds should run the whole matrix.
#93 attempts to redeem this by fully changing into the CI use-case, but I don't think that is user friendly because cross compiling is difficult, and we want people making GDExtensions to provide builds for all relevant platforms.

For this reason, I split the file into their respective use-cases, hopefully that solves the problem adequately.