### PR TITLE
Add subdirectories to source file collection logic in SConstruct using os.walk

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -38,7 +38,11 @@ Run the following command to download godot-cpp:
 env = SConscript("godot-cpp/SConstruct", {"env": env, "customs": customs})
 
 env.Append(CPPPATH=["src/"])
-sources = Glob("src/*.cpp")
+sources = []
+# Recursively add every .cpp file in the src directory.
+for folder_path, _, _ in os.walk("src"):
+    if not folder_path.endswith(os.sep + "gen"): # The doc data in src/gen is added later
+        sources += Glob(os.path.join(folder_path, "*.cpp"))
 
 if env["target"] in ["editor", "template_debug"]:
     try:


### PR DESCRIPTION
This is a resubmit of #98  which was reverted due to the collection conflicting with the generated files for documentation. 
This pull request proposes adding automatic file collection using os.walk so that source files in subdirectories of src/ get properly detected by SConstruct.