### PR TITLE
Fix macos.double.release and web.wasm32.double.debug paths in example.gdextension

### DIFF
--- a/demo/bin/example.gdextension
+++ b/demo/bin/example.gdextension
@@ -8,7 +8,7 @@ compatibility_minimum = "4.1"
 macos.single.debug = "./macos/libEXTENSION-NAME.macos.template_debug.dylib"
 macos.double.debug = "./macos/libEXTENSION-NAME.macos.template_debug.double.dylib"
 macos.single.release = "./macos/libEXTENSION-NAME.macos.template_release.dylib"
-macos.double.release = "./macos/libEXTENSION-NAME.macos.template_debug.double.dylib"
+macos.double.release = "./macos/libEXTENSION-NAME.macos.template_release.double.dylib"
 
 ios.arm64.single.debug = "./ios/libEXTENSION-NAME.ios.template_debug.arm64.dylib"
 ios.arm64.double.debug = "./ios/libEXTENSION-NAME.ios.template_debug.arm64.double.dylib"
@@ -51,6 +51,6 @@ android.arm64.single.release = "./android/libEXTENSION-NAME.android.template_rel
 android.arm64.double.release = "./android/libEXTENSION-NAME.android.template_release.arm64.double.so"
 
 web.wasm32.single.debug = "./web/libEXTENSION-NAME.web.template_debug.wasm32.nothreads.wasm"
-web.wasm32.double.debug = "./web/libEXTENSION-NAME.web.template_release.wasm32.double.nothreads.wasm"
+web.wasm32.double.debug = "./web/libEXTENSION-NAME.web.template_debug.wasm32.double.nothreads.wasm"
 web.wasm32.single.release = "./web/libEXTENSION-NAME.web.template_release.wasm32.nothreads.wasm"
 web.wasm32.double.release = "./web/libEXTENSION-NAME.web.template_release.wasm32.double.nothreads.wasm"


### PR DESCRIPTION
This PR corrects two errors:
- macos.double.release pointed to template_debug instead of template_release
- web.wasm32.double.debug pointed to template_release instead of template_debug