### PR TITLE
Add reloadable flag to gdextension file

### DIFF
--- a/project/bin/example.gdextension
+++ b/project/bin/example.gdextension
@@ -2,6 +2,7 @@
 
 entry_symbol = "example_library_init"
 compatibility_minimum = "4.1"
+reloadable = false
 
 [libraries]
 ; Relative paths ensure that our GDExtension can be placed anywhere in the project directory.


### PR DESCRIPTION
adds the reloadable flag to the .gdextension file for quickly getting started and having the extension be reloadable almost from the get-go