### PR TITLE
remove caching of the LIBNAME in CMake configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.17)
 if(CMAKE_C_COMPILER)
 endif()
 
-set(LIBNAME "EXTENSION-NAME" CACHE STRING "The name of the library")
+set(LIBNAME "EXTENSION-NAME") # "The name of the library"
 set(GODOT_PROJECT_DIR "project" CACHE STRING "The directory of a Godot project folder")
 
 # Make sure all the dependencies are satisfied


### PR DESCRIPTION
This change lets the generated run configuration in Rider/CLion to updated as soon as the library name is changed, fixes https://youtrack.jetbrains.com/issue/RIDER-136871

Specifically:
1. Rename "EXTENSION-NAME" to "NEW-NAME" and reloading CMake should update the run-configuration
<img width="878" height="340" alt="image" src="https://github.com/user-attachments/assets/e76aa859-590f-4e89-bf5e-d9c1bd66a65e" />

When the name is CACHED, only manual removal of the `cmake-build-debug` folder would help to regenerate the run configuration.

There is also another problem with the cached name even outside of Rider/CLion.
If you rename the library and call `cmake --build /Users/ivan.shakhov/Projects/MyExtension/cmake-build-debug --target all -- -j 14`, using the previously used folder `cmake-build-debug`, it would build the library with the previously cached name.