### PR TITLE
Update GitHub Actions (Node.js 20 deprecation)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       # Clone this repository
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
 

--- a/.github/workflows/make_build.yml
+++ b/.github/workflows/make_build.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       # Clone this repository
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
 
@@ -84,7 +84,7 @@ jobs:
 
       # Upload the build
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: godot-cpp-template-${{ matrix.target.platform }}-${{ matrix.target.arch }}-${{ matrix.float-precision }}-${{ matrix.target-type }}
           path: |
@@ -97,7 +97,7 @@ jobs:
     needs: build
     steps:
       - name: Merge Artifacts
-        uses: actions/upload-artifact/merge@v4
+        uses: actions/upload-artifact/merge@v7
         with:
           name: godot-cpp-template
           pattern: godot-cpp-template-*


### PR DESCRIPTION
This is to update from Node.js 20 to Node.js 24, as [GitHub has deprecated support and will remove Node.js 20 later this year](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). This only updates the actions called directly by workflows in godot-cpp-template. The workflows also call actions from godot-cpp, which will be updated in https://github.com/godotengine/godot-cpp/pull/1971 .