### PR TITLE
Help IDEs resolve gen/include immediately

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,9 @@ if(NOT EXISTS "${CMAKE_CURRENT_LIST_DIR}/godot-cpp/src")
 endif()
 add_subdirectory(godot-cpp SYSTEM)
 
+# Create the gen directory at configure time so IDEs can see generated headers immediately after generate_bindings
+file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/godot-cpp/gen/include")
+
 # Add godot-cpp's module path and include the exported functions.
 # This is made available for documentation generation
 set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${godot-cpp_SOURCE_DIR}/cmake")


### PR DESCRIPTION
Create the godot-cpp/gen/include directory at configure time so IDEs can see generated headers immediately after generate_bindings target produces them.

The problematic use-case, which I have fixed for Rider, CLion and VS:
1. clone a fresh copy of godot-cpp-template
2. open `example_class.cpp`
observe red code
3. call `generate_bindings` target
still observe red code, while expected result would be to see all resolved.

Notes:
 - maybe this should be done somewhere in the godot-cpp, not sure.
 - It would be even nicer to call the generate_bindings target in the design time, but that would be arguable bigger change.