### PR TITLE
bump CMake requirement to 3.25

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-# Using the same minimum as the godot-cpp project
-cmake_minimum_required(VERSION 3.17)
+# Requires 3.25 because of execute_process, SYSTEM keyword, REQUIRED keyword
+cmake_minimum_required(VERSION 3.25)
 
 # Silence unused variable warning when specified from toolchain
 if(CMAKE_C_COMPILER)


### PR DESCRIPTION
Using [SYSTEM] keyword added in CMake 3.25
https://cmake.org/cmake/help/v3.25/command/add_subdirectory.html?highlight=add_subdirectory

Aslo find_program(... REQUIRED) — added in 3.18
https://cmake.org/cmake/help/latest/command/find_program.html