### PR TITLE
CMake: Small fix for doc source consumption missing quotes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ file(GLOB_RECURSE DOC_XML LIST_DIRECTORIES NO CONFIGURE_DEPENDS "${PROJECT_SOURC
 # conditionally add doc data to compile output
 if(DOC_XML)
     if(GODOTCPP_TARGET MATCHES "editor|template_debug")
-        target_doc_sources(${LIBNAME} ${DOC_XML})
+        target_doc_sources(${LIBNAME} "${DOC_XML}")
     endif()
 endif()
 


### PR DESCRIPTION
Missing quotes only processes the first doc source xml file.
Issue reported to godot-cpp 1987

Fixes https://github.com/godotengine/godot-cpp-template/issues/123