### PR TITLE
CMake - emscripten hack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,9 @@ if(NOT EXISTS "${CMAKE_CURRENT_LIST_DIR}/godot-cpp/src")
 endif()
 add_subdirectory(godot-cpp SYSTEM)
 
+# When compiling for emscripten, this toolchainhack needs to be included.
+# set(CMAKE_PROJECT_<project-name>_INCLUDE ${godot-cpp_SOURCE_DIR}/cmake/emsdkHack.cmake)
+
 # Create the gen directory at configure time so IDEs can see generated headers immediately after generate_bindings
 file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/godot-cpp/gen/include")
 


### PR DESCRIPTION
Add a commented out line for the emscripten hack to indicate what to do when compiling for the platform.
Resolves #99

Because the project command has not been specified yet we don't have knowledge of the toolchain, so I've left this commented out. The only way I can imagine is to guard it with a variable, but I think that can be left upto the user of the template.